### PR TITLE
Fix if brokerId is not set

### DIFF
--- a/api/StigaAPIConnectionMQTT.js
+++ b/api/StigaAPIConnectionMQTT.js
@@ -12,6 +12,9 @@ const StigaAPIComponent = require('./StigaAPIComponent');
 
 class StigaAPIConnectionMQTT extends StigaAPIComponent {
     static getBrokerURL(brokerId) {
+        if (brokerId === undefined) {
+            brokerId = "broker";
+        }
         return `mqtts://robot-mqtt-${brokerId}.stiga.com:8883`;
     }
     static getBrokerUsername() {


### PR DESCRIPTION
This fixes issue #1.
In my case the brokerId is not set and therefore the mqtt url was build to mqtts://robot-mqtt-undefined.stiga.com:8883. With this fix the mqtt url is set to mqtts://robot-mqtt-broker.stiga.com:8883 if the brokerId is not set.